### PR TITLE
Translator.vue: Add error handling and user feedback

### DIFF
--- a/src/components/Translator.vue
+++ b/src/components/Translator.vue
@@ -18,6 +18,7 @@ declare global {
 }
 
 const supported = 'Translator' in self;
+const errorMessage = ref<string | null>(null);
 
 const sourceLanguage = ref<string>('en');
 const targetLanguage = ref<string>('ja');
@@ -28,7 +29,14 @@ const output = ref<string>('');
 const translator = ref<any>(null);
 
 const createTranslator = async (): Promise<void> => {
-  if (!supported) return;
+  if (!supported) {
+    errorMessage.value = 'Your browser does not support the Translator API.';
+    return;
+  }
+
+  if (translator.value) {
+    translator.value.destroy();
+  }
 
   output.value = 'Creating translator...';
   try {
@@ -38,12 +46,12 @@ const createTranslator = async (): Promise<void> => {
     });
 
     if (translatorAvailability === 'unavailable') {
-      alert(`Translator is unavailable for ${sourceLanguage.value} → ${targetLanguage.value}.`);
+      errorMessage.value = `Translator is unavailable for ${sourceLanguage.value} → ${targetLanguage.value}.`;
       return;
     }
   } catch (error: unknown) {
     if (error instanceof Error) {
-      alert(`Error: ${error.message}`);
+      errorMessage.value = `Error: ${error.message}`;
     }
     return;
   }
@@ -64,24 +72,39 @@ const createTranslator = async (): Promise<void> => {
 
 const translate = async (): Promise<void> => {
   if (!supported) {
-    alert('Your browser does not support the Translator API.');
+    errorMessage.value = 'Your browser does not support the Translator API.';
     return;
   }
 
   if (!translator.value) {
-    alert('Please create a translator first.');
+    errorMessage.value = 'Please create a translator first.';
     return;
   }
 
-  output.value = 'Translating...';
-  output.value = await translator.value.translate(input.value);
+  try {
+    errorMessage.value = null;
+    output.value = 'Translating...';
+    output.value = await translator.value.translate(input.value);
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      errorMessage.value = `Error: ${error.message}`;
+    }
+  }
 };
 </script>
 
 <template>
   <div class="translator">
-    <div v-if="!supported">
-      Your browser does not support the Translator API.
+    <div v-if="errorMessage" class="alert" role="alert">
+      <span>{{ errorMessage }}</span>
+      <button
+        class="alert-dismiss"
+        type="button"
+        aria-label="Dismiss error"
+        @click="errorMessage = null"
+      >
+        ×
+      </button>
     </div>
 
     <textarea
@@ -120,11 +143,39 @@ const translate = async (): Promise<void> => {
   gap: 1em;
 }
 
+.alert {
+  padding: 1em;
+  background-color: #ffdddd;
+  border-radius: 0.5em;
+  color: #a70000;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1em;
+}
+
+.alert-dismiss {
+  background: none;
+  border: none;
+  color: #a70000;
+  font-family: inherit;
+  font-size: 1.2em;
+  cursor: pointer;
+  padding: 0 0.5em;
+  border-radius: 0.5em;
+}
+
+.alert-dismiss:focus {
+  outline: 2px solid #6366F1;
+  background: #ffeaea;
+}
+
 input, textarea {
   font: inherit;
   padding: 0.5em;
   border: 1px solid #ccc;
   border-radius: 0.5em;
+  min-width: 0;
 }
 
 .translator-input, .translator-output {

--- a/src/style.css
+++ b/src/style.css
@@ -14,8 +14,7 @@
 }
 
 body {
-  margin: 0;
-  min-width: 320px;
+  margin: 0 1em;
 }
 
 #app {


### PR DESCRIPTION
This pull request improves error handling and user feedback in the `Translator.vue` component by introducing a dismissible error alert and replacing browser alerts with in-app error messages. It also adds styling for the new alert and makes a minor layout adjustment in `style.css`.

**Error handling and user feedback improvements:**

* Replaced all `alert()` calls with an `errorMessage` reactive property, which is displayed to the user in a dismissible alert within the UI instead of a blocking popup. This includes handling browser support errors, translator availability, and translation errors. [[1]](diffhunk://#diff-fbc2950feca2e59f8f2e73edc2a46b4ddc607781d5099a9aa6abdaa6f689e48dR21) [[2]](diffhunk://#diff-fbc2950feca2e59f8f2e73edc2a46b4ddc607781d5099a9aa6abdaa6f689e48dL31-R39) [[3]](diffhunk://#diff-fbc2950feca2e59f8f2e73edc2a46b4ddc607781d5099a9aa6abdaa6f689e48dL41-R54) [[4]](diffhunk://#diff-fbc2950feca2e59f8f2e73edc2a46b4ddc607781d5099a9aa6abdaa6f689e48dL67-R107)
* Added a dismissible error alert to the template, allowing users to clear error messages without reloading the page.

**Styling updates:**

* Added new CSS classes for the `.alert` and `.alert-dismiss` elements to style the error alert and its dismiss button, including focus states for accessibility.
* Adjusted the body margin in `style.css` for improved layout.